### PR TITLE
Update rpc-call.md

### DIFF
--- a/i18n/cn/docusaurus-plugin-content-docs/current/advance/rpc-call.md
+++ b/i18n/cn/docusaurus-plugin-content-docs/current/advance/rpc-call.md
@@ -188,14 +188,14 @@ etcd中的`Key`必须要和user rpc服务配置中Key一致
 type ServiceContext struct {
     Config  config.Config
     Example rest.Middleware
-    UserRpc user.User
+    UserRpc userclient.User
 }
 
 func NewServiceContext(c config.Config) *ServiceContext {
     return &ServiceContext{
         Config:  c,
         Example: middleware.NewExampleMiddleware().Handle,
-        UserRpc: user.NewUser(zrpc.MustNewClient(c.UserRpc)),
+        UserRpc: userclient.NewUser(zrpc.MustNewClient(c.UserRpc)),
     }
 }
 ```


### PR DESCRIPTION
在最新1.4.0版本中，使用中发现生成的代码中增加了${domain}client的包（这里是userclient包），相应的客户端代码也移到了这个包，这与原文描述不符