### PR TITLE
Update micro-service.md

### DIFF
--- a/docs/quick-start/micro-service.md
+++ b/docs/quick-start/micro-service.md
@@ -216,20 +216,20 @@ grpc directive details refer to https://grpc.io/docs/languages/go/quickstart/
 
   import (
       "go-zero-demo/mall/order/api/internal/config"
-      "go-zero-demo/mall/user/rpc/user"
+      "go-zero-demo/mall/user/rpc/types/user"
 
       "github.com/zeromicro/go-zero/zrpc"
   )
 
   type ServiceContext struct {
       Config  config.Config
-      UserRpc user.User
+      UserRpc user.UserClient
   }
 
   func NewServiceContext(c config.Config) *ServiceContext {
       return &ServiceContext{
           Config:  c,
-          UserRpc: user.NewUser(zrpc.MustNewClient(c.UserRpc)),
+          UserRpc: user.NewUserClient(zrpc.MustNewClient(c.UserRpc).Conn()),
       }
   }
   ```


### PR DESCRIPTION
Correct doc: `UserRpc` injection.

There're some mistakes in the micro-service guide regarding importing user RPC client and instantiating it.

Import error when following the current doc:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/3942264/229264320-6e6e3b68-9e38-488c-89ea-57d1a5ba2d17.png">

Environment:
```
protoc-gen-go-grpc v1.3.0
protoc             v3.19.4
```