### PR TITLE
fix:the actual response does not match the document

### DIFF
--- a/docs/tasks/cli/grpc-demo.md
+++ b/docs/tasks/cli/grpc-demo.md
@@ -163,7 +163,7 @@ grpcui 是一个gRPC UI 调试工具，用于访问 gRPC 服务，详情可参�
 
 ```json
 {
-    "message": "me"
+     "pong": "pong"
 }
 ```
 </TabItem>


### PR DESCRIPTION
[https://go-zero.dev/docs/tasks/cli/grpc-demo](url)
In the webpage displayed at the address above,when we use postman to send a ping request,the actual is `"pong": "pong"` ,but,in this page is `"message": "me"`

