### PR TITLE
Fix incorrect YAML format in logging configuration

### DIFF
--- a/docs/tutorials/log/log.md
+++ b/docs/tutorials/log/log.md
@@ -174,6 +174,7 @@ func main() {
 配置文件如下：
 
 ```yaml
-Mode: file
-Encoding: json
+Log:
+  Mode: file
+  Encoding: json
 ```


### PR DESCRIPTION
Corrected the styling of YAML configuration examples in the logging tutorial document. This ensures that users can properly set up their logging based on accurate configuration samples.

File changed: docs/tutorials/log/log.md